### PR TITLE
Get certmanager to reconcile across clusters

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -45,6 +45,8 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/metrics"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 	"github.com/cert-manager/cert-manager/pkg/util/profiling"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
@@ -334,11 +336,13 @@ func startLeaderElection(ctx context.Context, opts *options.ControllerOptions, l
 		Identity:      id + "-external-cert-manager-controller",
 		EventRecorder: recorder,
 	}
+	corev1cl := corev1client.NewWithCluster(leaderElectionClient.CoreV1().RESTClient(), "admin")
+	coordinationv1cl := coordinationv1.NewWithCluster(leaderElectionClient.CoordinationV1().RESTClient(), "admin")
 	ml, err := resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
 		opts.LeaderElectionNamespace,
 		lockName,
-		leaderElectionClient.CoreV1(),
-		leaderElectionClient.CoordinationV1(),
+		corev1cl,
+		coordinationv1cl,
 		lc,
 	)
 	if err != nil {

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -336,6 +336,7 @@ func startLeaderElection(ctx context.Context, opts *options.ControllerOptions, l
 		Identity:      id + "-external-cert-manager-controller",
 		EventRecorder: recorder,
 	}
+	// TODO(kcp): Hardcoded to admin cluster for now. Figure out what is to be done later.
 	corev1cl := corev1client.NewWithCluster(leaderElectionClient.CoreV1().RESTClient(), "admin")
 	coordinationv1cl := coordinationv1.NewWithCluster(leaderElectionClient.CoordinationV1().RESTClient(), "admin")
 	ml, err := resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -236,7 +236,6 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	if ns == "" {
 		ns = o.Namespace
 	}
-	fmt.Println("creating certificate request here")
 	req, err = o.CMClient.CertmanagerV1().CertificateRequests(ns).Create(ctx, req, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating CertificateRequest: %w", err)

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -236,6 +236,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	if ns == "" {
 		ns = o.Namespace
 	}
+	fmt.Println("creating certificate request here")
 	req, err = o.CMClient.CertmanagerV1().CertificateRequests(ns).Create(ctx, req, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating CertificateRequest: %w", err)

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -151,7 +151,6 @@ func (o *Options) GetResources(ctx context.Context, crtName string) (*Data, erro
 		return nil, err
 	}
 
-	fmt.Println("getting certificate events")
 	// If no events found, crtEvents would be nil and handled down the line in DescribeEvents
 	crtEvents, err := clientSet.CoreV1().Events(crt.Namespace).Search(ctl.Scheme, crtRef)
 	if err != nil {

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -150,6 +150,8 @@ func (o *Options) GetResources(ctx context.Context, crtName string) (*Data, erro
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println("getting certificate events")
 	// If no events found, crtEvents would be nil and handled down the line in DescribeEvents
 	crtEvents, err := clientSet.CoreV1().Events(crt.Namespace).Search(ctl.Scheme, crtRef)
 	if err != nil {

--- a/internal/controller/certificates/apply.go
+++ b/internal/controller/certificates/apply.go
@@ -41,7 +41,7 @@ func ApplyStatus(ctx context.Context, cl cmclient.Interface, fieldManager string
 		return err
 	}
 
-	client := certmanagerv1.NewWithCluster(cl.AcmeV1().RESTClient(), ctx.Value("clusterName").(string))
+	client := certmanagerv1.NewWithCluster(cl.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
 	_, err = client.Certificates(crt.Namespace).Patch(
 		ctx, crt.Name, apitypes.ApplyPatchType, crtData,
 		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",

--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -242,13 +242,8 @@ type Gatherer struct {
 func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificate) (Input, error) {
 	log := logf.FromContext(ctx)
 	// Attempt to fetch the Secret being managed but tolerate NotFound errors.
-	fmt.Println("finding dataForCertificate****", crt.GetClusterName())
 	secret, err := g.SecretLister.Secrets(crt.Namespace).Get(crt.Spec.SecretName)
-	if apierrors.IsNotFound(err) {
-		fmt.Println("not founddd")
-	}
 	if err != nil && !apierrors.IsNotFound(err) {
-		fmt.Println("secret not found", crt.Spec.SecretName)
 		return Input{}, err
 	}
 
@@ -317,7 +312,6 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 		log.V(logf.DebugLevel).Info("Found no CertificateRequest resources owned by this Certificate for the next revision", "revision", nextCRRevision)
 	}
 
-	fmt.Println("here returning input data", crt.GetClusterName())
 	return Input{
 		Certificate:            crt,
 		Secret:                 secret,

--- a/internal/controller/certificates/policies/gatherer.go
+++ b/internal/controller/certificates/policies/gatherer.go
@@ -242,8 +242,13 @@ type Gatherer struct {
 func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificate) (Input, error) {
 	log := logf.FromContext(ctx)
 	// Attempt to fetch the Secret being managed but tolerate NotFound errors.
+	fmt.Println("finding dataForCertificate****", crt.GetClusterName())
 	secret, err := g.SecretLister.Secrets(crt.Namespace).Get(crt.Spec.SecretName)
+	if apierrors.IsNotFound(err) {
+		fmt.Println("not founddd")
+	}
 	if err != nil && !apierrors.IsNotFound(err) {
+		fmt.Println("secret not found", crt.Spec.SecretName)
 		return Input{}, err
 	}
 
@@ -312,6 +317,7 @@ func (g *Gatherer) DataForCertificate(ctx context.Context, crt *cmapi.Certificat
 		log.V(logf.DebugLevel).Info("Found no CertificateRequest resources owned by this Certificate for the next revision", "revision", nextCRRevision)
 	}
 
+	fmt.Println("here returning input data", crt.GetClusterName())
 	return Input{
 		Certificate:            crt,
 		Secret:                 secret,

--- a/internal/controller/issuers/apply.go
+++ b/internal/controller/issuers/apply.go
@@ -64,7 +64,8 @@ func ApplyClusterIssuerStatus(ctx context.Context, cl cmclient.Interface, fieldM
 		return err
 	}
 
-	_, err = cl.CertmanagerV1().ClusterIssuers().Patch(
+	client := certmanagerv1.NewWithCluster(cl.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+	_, err = client.ClusterIssuers().Patch(
 		ctx, issuer.Name, apitypes.ApplyPatchType, issuerData,
 		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",
 	)

--- a/internal/controller/issuers/apply.go
+++ b/internal/controller/issuers/apply.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -41,7 +42,8 @@ func ApplyIssuerStatus(ctx context.Context, cl cmclient.Interface, fieldManager 
 		return err
 	}
 
-	_, err = cl.CertmanagerV1().Issuers(issuer.Namespace).Patch(
+	client := certmanagerv1.NewWithCluster(cl.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+	_, err = client.Issuers(issuer.Namespace).Patch(
 		ctx, issuer.Name, apitypes.ApplyPatchType, issuerData,
 		metav1.PatchOptions{Force: pointer.Bool(true), FieldManager: fieldManager}, "status",
 	)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -118,6 +118,7 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 		"exclude_cn_from_sans": "true",
 	}
 
+	// TODO(kcp): Later: since a post request is being sent, verify if we need to send the clusterName
 	vaultIssuer := v.issuer.GetSpec().Vault
 	url := path.Join("/v1", vaultIssuer.Path)
 

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -67,10 +67,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	log := logf.FromContext(ctx).WithValues("dnsName", ch.Spec.DNSName, "type", ch.Spec.Type)
 	ctx = logf.NewContext(ctx, log)
 
-	clusterName := ch.GetClusterName()
-	ctx = context.WithValue(ctx, "clusterName", clusterName)
-
-	client := acmev1.NewWithCluster(c.cmClient.AcmeV1().RESTClient(), clusterName)
+	client := acmev1.NewWithCluster(c.cmClient.AcmeV1().RESTClient(), ctx.Value("clusterName").(string))
 
 	oldChal := ch
 	ch = ch.DeepCopy()
@@ -97,7 +94,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 		return nil
 	}
 
-	ch.Spec.IssuerRef.Name = clusters.ToClusterAwareKey(clusterName, ch.Spec.IssuerRef.Name)
+	ch.Spec.IssuerRef.Name = clusters.ToClusterAwareKey(ctx.Value("clusterName").(string), ch.Spec.IssuerRef.Name)
 	genericIssuer, err := c.helper.GetGenericIssuer(ch.Spec.IssuerRef, ch.Namespace)
 	if err != nil {
 		return fmt.Errorf("error reading (cluster)issuer %q: %v", ch.Spec.IssuerRef.Name, err)

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -104,5 +104,8 @@ func (c *Controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, cr))
+
+	// Include clusterName in the context
+	ctx = context.WithValue(ctx, "clusterName", cr.GetClusterName())
 	return c.Sync(ctx, cr)
 }

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -83,6 +83,10 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 	secretName := issuerObj.GetSpec().CA.SecretName
 	resourceNamespace := c.issuerOptions.ResourceNamespace(issuerObj)
 
+	// Though client scoped calls are not used here, making the context cluster scoped
+	// for future use.
+	ctx = context.WithValue(ctx, "clusterName", cr.GetClusterName())
+
 	// get a copy of the CA certificate named on the Issuer
 	caCerts, caKey, err := kube.SecretTLSKeyPairAndCA(ctx, c.secretsLister, resourceNamespace, issuerObj.GetSpec().CA.SecretName)
 	if k8sErrors.IsNotFound(err) {

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned.go
@@ -80,6 +80,9 @@ func NewSelfSigned(ctx *controllerpkg.Context) certificaterequests.Issuer {
 func (s *SelfSigned) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj cmapi.GenericIssuer) (*issuer.IssueResponse, error) {
 	log := logf.FromContext(ctx, "sign")
 
+	// Though client calls aren't being made, scoping the context for future use.
+	ctx = context.WithValue(ctx, "clusterName", cr.GetClusterName())
+
 	resourceNamespace := s.issuerOptions.ResourceNamespace(issuerObj)
 
 	secretName, ok := cr.ObjectMeta.Annotations[cmapi.CertificateRequestPrivateKeyAnnotationKey]

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -43,6 +43,7 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -177,6 +178,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	log = logf.WithResource(log, crt)
 	ctx = logf.NewContext(ctx, log)
+	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
 
 	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionIssuing,
@@ -434,7 +436,8 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 			},
 		})
 	} else {
-		_, err := c.client.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+		client := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+		_, err := client.Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -137,7 +137,6 @@ func init() {
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	fmt.Println("hereee!!!!!!!!!! triggering keymanager controller")
 	log := logf.FromContext(ctx).WithValues("key", key)
 	ctx = logf.NewContext(ctx, log)
 
@@ -148,7 +147,6 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	fmt.Println("certificate name *****************", crt.GetName(), crt.GetClusterName())
 	if apierrors.IsNotFound(err) {
 		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
 		return nil
@@ -270,7 +268,6 @@ func (c *controller) createNextPrivateKeyRotationPolicyNever(ctx context.Context
 	}
 
 	nextPkSecret, err := c.createNewPrivateKeySecret(ctx, crt, pk)
-	fmt.Println("creating a new secret in cluster", crt.GetClusterName())
 	if err != nil {
 		return err
 	}
@@ -354,8 +351,6 @@ func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.C
 		return nil, err
 	}
 
-	fmt.Println("********************", crt.GetClusterName(), "*****************")
-
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       crt.Namespace,
@@ -375,7 +370,6 @@ func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.C
 		s.GenerateName = crt.Name + "-"
 	}
 
-	fmt.Println("here while creating secret &&&&&&&&&&&&&", crt.GetClusterName())
 	cl := corev1client.NewWithCluster(c.coreClient.CoreV1().RESTClient(), crt.GetClusterName())
 	s, err = cl.Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -100,6 +100,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		return err
 	}
 
+	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
+
 	// Update that Certificates metrics
 	c.metrics.UpdateCertificate(ctx, crt)
 

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -230,7 +230,7 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 			},
 		})
 	} else {
-		cl := certmanagerv1.NewWithCluster(c.client.AcmeV1().RESTClient(), ctx.Value("clusterName").(string))
+		cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
 		_, err := cl.Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 		return err
 	}

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -18,6 +18,7 @@ package readiness
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -148,6 +149,9 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
+	fmt.Println("readiness controller-----", crt.GetClusterName())
+	fmt.Println(crt.GetClusterName())
+	fmt.Println(err)
 
 	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
 
@@ -160,6 +164,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	input, err := c.gatherer.DataForCertificate(ctx, crt)
+	fmt.Println("hereeeeeeeee!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println(input.Certificate, "*******", input.Secret, "***********")
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -18,7 +18,6 @@ package readiness
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -149,12 +148,6 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	fmt.Println("readiness controller-----", crt.GetClusterName())
-	fmt.Println(crt.GetClusterName())
-	fmt.Println(err)
-
-	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
-
 	if apierrors.IsNotFound(err) {
 		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
 		return nil
@@ -163,9 +156,9 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		return err
 	}
 
+	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
+
 	input, err := c.gatherer.DataForCertificate(ctx, crt)
-	fmt.Println("hereeeeeeeee!!!!!!!!!!!!!!!!!!!!!")
-	fmt.Println(input.Certificate, "*******", input.Secret, "***********")
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -42,6 +42,7 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	cminformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
@@ -146,6 +147,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
+
+	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
 
 	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionIssuing,
@@ -258,7 +261,9 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 		// that we create a new one for this issuance.
 		if req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) {
 			log.V(logf.DebugLevel).Info("Found a failed CertificateRequest for previous issuance of this revision, deleting...")
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+
+			cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
@@ -272,10 +277,13 @@ func (c *controller) deleteRequestsWithoutRevision(ctx context.Context, reqs ...
 	log := logf.FromContext(ctx)
 	var remaining []*cmapi.CertificateRequest
 	for _, req := range reqs {
+		// TODO(kcp): Verify if clustername of certificate and certificate request are the same.
+		// Passing the clustername from certificate request for now.
+		cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), req.GetClusterName())
 		log := logf.WithRelatedResource(log, req)
 		if req.Annotations == nil || req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey] == "" {
 			log.V(logf.DebugLevel).Info("Deleting CertificateRequest as it does not contain a revision annotation")
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
@@ -284,7 +292,7 @@ func (c *controller) deleteRequestsWithoutRevision(ctx context.Context, reqs ...
 		_, err := strconv.ParseInt(reqRevisionStr, 10, 0)
 		if err != nil {
 			log.V(logf.DebugLevel).Info("Deleting CertificateRequest as it contains an invalid revision annotation")
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
@@ -320,16 +328,19 @@ func (c *controller) deleteRequestsNotMatchingSpec(ctx context.Context, crt *cma
 	for _, req := range reqs {
 		log := logf.WithRelatedResource(log, req)
 		violations, err := certificates.RequestMatchesSpec(req, crt.Spec)
+
+		// creating client with cluster name of the certificate instead of certificate request.
+		cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
 		if err != nil {
 			log.Error(err, "Failed to check if CertificateRequest matches spec, deleting CertificateRequest")
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
 		}
 		if len(violations) > 0 {
 			log.V(logf.InfoLevel).WithValues("violations", violations).Info("CertificateRequest does not match requirements on certificate.spec, deleting CertificateRequest", "violations", violations)
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
@@ -345,7 +356,9 @@ func (c *controller) deleteRequestsNotMatchingSpec(ctx context.Context, crt *cma
 		}
 		if !matches {
 			log.V(logf.DebugLevel).Info("CertificateRequest contains a CSR that does not have the same public key as the stored next private key secret, deleting CertificateRequest")
-			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
+			// TODO(kcp): Verify if the clustername of certificate request or certificate needs to be passed. Adding
+			// todo as a caution.
+			if err := cl.CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
@@ -395,7 +408,8 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 		},
 	}
 
-	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
+	cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+	cr, err = cl.CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{FieldManager: c.fieldManager})
 	if err != nil {
 		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
 		return err

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -226,7 +226,7 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 			Status:     cmapi.CertificateStatus{Conditions: conditions},
 		})
 	} else {
-		cl := certmanagerv1.NewWithCluster(c.client.AcmeV1().RESTClient(), ctx.Value("clusterName").(string))
+		cl := certmanagerv1.NewWithCluster(c.client.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
 		_, err := cl.Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 		return err
 	}

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -18,7 +18,6 @@ package trigger
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -64,7 +63,6 @@ type controller struct {
 	certificateRequestLister cmlisters.CertificateRequestLister
 	secretLister             corelisters.SecretLister
 	client                   cmclient.Interface
-	cluster                  cmclient.Cluster
 	recorder                 record.EventRecorder
 	scheduledWorkQueue       scheduler.ScheduledWorkQueue
 
@@ -82,7 +80,6 @@ type controller struct {
 func NewController(
 	log logr.Logger,
 	client cmclient.Interface,
-	cluster cmclient.Cluster,
 	factory informers.SharedInformerFactory,
 	cmFactory cminformers.SharedInformerFactory,
 	recorder record.EventRecorder,
@@ -124,7 +121,6 @@ func NewController(
 		certificateRequestLister: certificateRequestInformer.Lister(),
 		secretLister:             secretsInformer.Lister(),
 		client:                   client,
-		cluster:                  cluster,
 		recorder:                 recorder,
 		scheduledWorkQueue:       scheduler.NewScheduledWorkQueue(clock, queue.Add),
 		fieldManager:             fieldManager,
@@ -149,11 +145,6 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	crt, err := c.certificateLister.Certificates(namespace).Get(name)
-	fmt.Println("clusterName of the returned certificate")
-	fmt.Println(crt.GetClusterName())
-
-	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
-
 	if apierrors.IsNotFound(err) {
 		log.V(logf.DebugLevel).Info("certificate not found for key", "error", err.Error())
 		return nil
@@ -161,6 +152,9 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
+
+	ctx = context.WithValue(ctx, "clusterName", crt.GetClusterName())
+
 	if apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionIssuing,
 		Status: cmmeta.ConditionTrue,
@@ -214,7 +208,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 // updateOrApplyStatus will update the controller status. If the
 // ServerSideApply feature is enabled, the managed fields will instead get
 // applied using the relevant Patch API call.
-// TODO: modify the client calls to cluster instead
+// TODO(kcp): modify the client calls to cluster instead
 func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certificate) error {
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
 		var conditions []cmapi.CertificateCondition
@@ -310,7 +304,6 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 
 	ctrl, queue, mustSync := NewController(log,
 		ctx.CMClient,
-		ctx.Cluster,
 		ctx.KubeSharedInformerFactory,
 		ctx.SharedInformerFactory,
 		ctx.Recorder,

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -150,6 +150,10 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
+
+	// Pass cluster scoped context to sync
+	ctx = context.WithValue(ctx, "clusterName", issuer.GetClusterName())
+
 	return c.Sync(ctx, issuer)
 }
 

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalissuers "github.com/cert-manager/cert-manager/internal/controller/issuers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
@@ -75,7 +76,8 @@ func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.Clu
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
 		return internalissuers.ApplyClusterIssuerStatus(ctx, c.cmClient, c.fieldManager, new)
 	} else {
-		_, err := c.cmClient.CertmanagerV1().ClusterIssuers().UpdateStatus(ctx, new, metav1.UpdateOptions{})
+		client := certmanagerv1.NewWithCluster(c.cmClient.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+		_, err := client.ClusterIssuers().UpdateStatus(ctx, new, metav1.UpdateOptions{})
 		return err
 	}
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -365,5 +365,5 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 		return contextClients{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
 
-	return contextClients{kubeClient.Cluster("admin"), cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
+	return contextClients{kubeClient.Cluster("*"), cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -333,7 +333,7 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 	}
 
 	// Create a Kubernetes api client
-	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	kubeClient, err := kubernetes.NewClusterForConfig(restConfig)
 	if err != nil {
 		return contextClients{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
@@ -343,7 +343,7 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
 		// Check if the gateway API CRDs are available. If they are not found
 		// return an error which will cause cert-manager to crashloopbackoff.
-		d := kubeClient.Discovery()
+		d := kubeClient.Cluster("*").Discovery()
 		resources, err := d.ServerResourcesForGroupVersion(gwapi.GroupVersion.String())
 		var GatewayAPINotAvailable = "the Gateway API CRDs do not seem to be present, but " + feature.ExperimentalGatewayAPISupport +
 			" is set to true. Please install the gateway-api CRDs."
@@ -365,5 +365,5 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 		return contextClients{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
 
-	return contextClients{kubeClient, cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
+	return contextClients{kubeClient.Cluster("admin"), cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -79,6 +79,8 @@ type Context struct {
 	RESTConfig *rest.Config
 	// Client is a Kubernetes clientset
 	Client kubernetes.Interface
+	// Cluster is a Kubernetes cluster interface
+	Cluster clientset.Cluster
 	// CMClient is a cert-manager clientset
 	CMClient clientset.Interface
 	// GWClient is a GatewayAPI clientset.
@@ -316,6 +318,7 @@ func (c *ContextFactory) Build(component ...string) (*Context, error) {
 type contextClients struct {
 	kubeClient       kubernetes.Interface
 	cmClient         clientset.Interface
+	cluster          clientset.Cluster
 	gwClient         gwclient.Interface
 	gatewayAvailable bool
 }
@@ -362,5 +365,5 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 		return contextClients{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
 
-	return contextClients{kubeClient, cmClient.Cluster("*"), gwClient, gatewayAvailable}, nil
+	return contextClients{kubeClient, cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -64,6 +64,7 @@ const resyncPeriod = 10 * time.Hour
 // Each component should be given distinct Contexts, built from the
 // ContextFactory that has configured the underlying client to use separate
 // User Agents.
+// TODO(kcp): Pass cluster interface for certmanager and k8s client
 type Context struct {
 	// RootContext is the root context for the controller
 	RootContext context.Context
@@ -79,8 +80,6 @@ type Context struct {
 	RESTConfig *rest.Config
 	// Client is a Kubernetes clientset
 	Client kubernetes.Interface
-	// Cluster is a Kubernetes cluster interface
-	Cluster clientset.Cluster
 	// CMClient is a cert-manager clientset
 	CMClient clientset.Interface
 	// GWClient is a GatewayAPI clientset.
@@ -315,10 +314,10 @@ func (c *ContextFactory) Build(component ...string) (*Context, error) {
 }
 
 // contextClients is a helper struct containing API clients.
+// TODO(kcp): Propagate cluster interfaces here too.
 type contextClients struct {
 	kubeClient       kubernetes.Interface
 	cmClient         clientset.Interface
-	cluster          clientset.Cluster
 	gwClient         gwclient.Interface
 	gatewayAvailable bool
 }
@@ -365,5 +364,6 @@ func buildClients(restConfig *rest.Config) (contextClients, error) {
 		return contextClients{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
 
-	return contextClients{kubeClient.Cluster("*"), cmClient.Cluster("*"), *cmClient, gwClient, gatewayAvailable}, nil
+	// TODO(kcp): Verify if gateway client needs to be scoped
+	return contextClients{kubeClient.Cluster("*"), cmClient.Cluster("*"), gwClient, gatewayAvailable}, nil
 }

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -142,6 +142,9 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	ctx = logf.NewContext(ctx, logf.WithResource(log, issuer))
+
+	// Pass a cluster scoped context to sync
+	ctx = context.WithValue(ctx, "clusterName", issuer.GetClusterName())
 	return c.Sync(ctx, issuer)
 }
 

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -46,7 +46,6 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
-	ctx = context.WithValue(ctx, "clusterName", iss.GetClusterName())
 	issuerCopy := iss.DeepCopy()
 	defer func() {
 		if saveErr := c.updateIssuerStatus(ctx, iss, issuerCopy); saveErr != nil {

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cert-manager/cert-manager/internal/controller/feature"
 	internalissuers "github.com/cert-manager/cert-manager/internal/controller/issuers"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	utilfeature "github.com/cert-manager/cert-manager/pkg/util/feature"
 )
@@ -45,6 +46,7 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
+	ctx = context.WithValue(ctx, "clusterName", iss.GetClusterName())
 	issuerCopy := iss.DeepCopy()
 	defer func() {
 		if saveErr := c.updateIssuerStatus(ctx, iss, issuerCopy); saveErr != nil {
@@ -76,7 +78,8 @@ func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.Iss
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ServerSideApply) {
 		return internalissuers.ApplyIssuerStatus(ctx, c.cmClient, c.fieldManager, new)
 	} else {
-		_, err := c.cmClient.CertmanagerV1().Issuers(new.Namespace).UpdateStatus(ctx, new, metav1.UpdateOptions{})
+		client := certmanagerv1.NewWithCluster(c.cmClient.CertmanagerV1().RESTClient(), ctx.Value("clusterName").(string))
+		_, err := client.Issuers(new.Namespace).UpdateStatus(ctx, new, metav1.UpdateOptions{})
 		return err
 	}
 }


### PR DESCRIPTION
With these changes, we have kubeclient scoped so the cert-manager can now reconcile and create secrets across logical and admin clusters. Tested it against a simple case of creating Issuer and Certificate in multiple logical clusters and checking if secrets are created.

Things still to do:
- [x] Modify[ AcmeV1()](https://pkg.go.dev/github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/acme/v1#AcmeV1Interface) client calls to be cluster scoped.
- [ ] Do some cleanup to pass [Cluster](https://github.com/fabianvf/cert-manager/blob/9c6b5492455fd86fab368f69149b56d0271b3026/pkg/client/clientset/versioned/clientset.go#L36) instead (or in addition to) client directly to the controllers - (intentionally deferred for a follow up, just to make sure if that is all what we need in controllers)